### PR TITLE
add ws-client.js which reconnects in nodejs. Fixes #3

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const WebSocket = require('ws');
+const WebSocketClient = require('./ws-client');
 
 export default class CertStreamClient{
     constructor(callback, skipHeartbeats = false) {
@@ -8,13 +8,13 @@ export default class CertStreamClient{
     }
 
     connect(){
-        this.ws = new WebSocket("wss://certstream.calidog.io/");
+        this.ws = new WebSocketClient("wss://certstream.calidog.io/");
 
-        this.ws.on('open', () => {
+        this.ws.onopen = () => {
             console.log("Connection established to certstream! Waiting for messages...");
-        });
+        };
 
-        this.ws.on('message', (message) => {
+        this.ws.onmessage = (message) => {
             let parsedMessage = JSON.parse(message);
 
             if (parsedMessage.message_type === "heartbeat" && this.skipHeartbeats) {
@@ -22,6 +22,7 @@ export default class CertStreamClient{
             }
 
             this.callback(parsedMessage, this.context);
-        });
+        };
     }
 };
+

--- a/src/ws-client.js
+++ b/src/ws-client.js
@@ -1,0 +1,58 @@
+const WebSocket = require("ws");
+
+export default class WebSocketClient {
+  constructor(url, reconnectInterval) {
+    this.url = url;
+    this.autoReconnectInterval = reconnectInterval || 5000;
+    this.instance = new WebSocket(this.url);
+    this.instance.on('open', () => {
+      this.onopen();
+    });
+
+    this.instance.on('message', (data, flags) => {
+      this.onmessage(data, flags);
+    });
+
+    this.instance.on('close', (e) => {
+      switch (e) {
+        // if its closed manually, then do not reconnect
+        case 1000:
+          break;
+        default:
+          this.reconnect(e);
+          break;
+      }
+      this.onclose(e);
+    });
+
+    this.instance.on('error', (e) => {
+      switch (e.code) {
+        case 'ECONNREFUSED':
+          this.reconnect(e);
+          break;
+        default:
+          this.onerror(e);
+          break;
+      }
+    });
+  }
+
+  send(data, option) {
+    try {
+      this.instance.send(data, option);
+    }
+    catch (e) {
+      this.instance.emit('error', e);
+    }
+  }
+  reconnect(e) {
+    console.log(`WebSocketClient: retry in ${this.autoReconnectInterval}ms`, e);
+
+    this.instance.removeAllListeners();
+    setTimeout(() => {
+      console.log('WebSocketClient: reconnecting...');
+      this.open(this.url);
+    }, this.autoReconnectInterval);
+  }
+}
+


### PR DESCRIPTION
  - modified src/index.js to accept events on onopen, onmessage instead of
    .on('open'), .on('message') etc.
  - ws-client.js would work with browser as well, if we
    add window.WebSocket detection to it. Not required for this fix.